### PR TITLE
Don't search with 'DOI:' string

### DIFF
--- a/bibfetch.pl
+++ b/bibfetch.pl
@@ -28,7 +28,6 @@ sub gscholar {
   $mech->agent_alias("Linux Mozilla");
   $mech->add_header(Cookie => "GSP=ID=$gid:CF=4");
 
-  $query = "doi:".$query if $doi;
   $query = "allintitle: ".$query unless ($fulltext or $doi);
   
   $query = uri_escape($query);


### PR DESCRIPTION
Turns out if you search on Google with "DOI: doi_string" it doesn't do as well if you just search for "dio_string".
